### PR TITLE
Fixed bug with SoundExplorer

### DIFF
--- a/jes/java/SoundExplorer.java
+++ b/jes/java/SoundExplorer.java
@@ -212,6 +212,11 @@ public class SoundExplorer implements MouseMotionListener, ActionListener,
 
         //display everything
         createWindow();
+        
+        //in sounds with less than 640 samples, this value would be zero causing errors
+        if (framesPerPixel < 1) {
+            handleFramesPerPixel(1);
+        }
     }
 
     /**


### PR DESCRIPTION
Opening a sound with less than 640 samples in the SoundExplorer was causing framesPerPixel to become 0; thus causing the explorer to not display the waveform.

        zoomOutWidth = 640;
        zoomInWidth = sound.getLengthInFrames();
        sampleWidth = zoomOutWidth;
        framesPerPixel = sound.getLengthInFrames() / sampleWidth;

Before:
![jesbefore](https://cloud.githubusercontent.com/assets/5061604/7418295/01f1c1dc-efac-11e4-9832-7c67adfc1626.PNG)

After:
![jesafter](https://cloud.githubusercontent.com/assets/5061604/7418299/0842dbd4-efac-11e4-91c3-4cec6341c4cc.PNG)
